### PR TITLE
Adjusting ignore file to allow localized python support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .bash_history
+.bash_profile
 .cache
 .gitconfig
+.pyenv
 .python-version
 .ssh
 site.retry


### PR DESCRIPTION
This (very small) commit adds ignore lines to the repository so
that localized Python (using pyenv and pyenv-virtualenv) can be
used on the ansible1 control host. This gives us more directed
control over that supporting Python environment, and insulates
us from OS-delivered patch updates.

For future reference, the basic procedure to get this working
on ansible1 involved first removing the system-managed "ansible"
package, adding some development packages required by pyenv,
and then installing pyenv and a localized Python instance
and modules directly into ansible1:/etc/ansible, as the
"ansible-admin" user. E.g.:

    $ sudo yum remove ansible
    $ sudo yum install gcc make \
                       bzip2 bzip2-devel \
                       readline readline-devel \
                       sqlite sqlite-devel \
                       openssl openssl-devel \
                       xz xz-devel

    $ sudo su - ansible-admin

        $ curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
        $ pyenv install 2.7.15
        $ pyenv virtualenv 2.7.15 ual-ansible-config
        $ pyenv local ual-ansible-config
        $ pip install pyvmomi ansible
        $ exit

    $ exit

We're sticking with latest-version Python2 for the moment, on the
assumption that there will be dependencies in Ansible's library
modules that might not be available for Python3.
